### PR TITLE
Use EditorAPI's save/restore selection to mark location for gif insert

### DIFF
--- a/N1-Jiffy/lib/gif-picker.es6
+++ b/N1-Jiffy/lib/gif-picker.es6
@@ -5,30 +5,18 @@ import {Popover} from 'nylas-component-kit';
 let giphy = require('giphy-api')('dc6zaTOxFJmzC');
 
 export class GifSaveState extends ComposerExtension {
-  static onBlur(editableNode, range, event) {
-    let elem = document.getElementsByClassName('contenteditable')[0];
-
-    if (document.getElementById('n1-gif-marker') !== null) {
-      var markerOld = document.getElementById('n1-gif-marker');
-      markerOld.outerHTML = '';
-      delete markerOld;
-    }
-
-    let r = document.createRange();
-    r.setStart(range.anchorNode, range.anchorOffset);
-    r.setEnd(range.anchorNode, range.anchorOffset);
-    let marker = document.createElement('span');
-    marker.id = 'n1-gif-marker';
-    r.insertNode(marker);
+  static sel = null;
+  static onBlur(editor, event) {
+    // Save the current selection when focus is lost
+    GifSaveState.sel = editor.currentSelection().exportSelection()
   }
 
-  static onFocus(editableNode, range, event) {
-    let elem = document.getElementsByClassName('contenteditable')[0];
-
-    if (document.getElementById('n1-gif-marker') !== null) {
-      var markerOld = document.getElementById('n1-gif-marker');
-      markerOld.outerHTML = '';
-      delete markerOld;
+  static onFocus(editor, event) {
+    // If we have a saved selection, restore and clear it
+    // when contenteditable is focused
+    if(GifSaveState.sel) {
+      editor.select(GifSaveState.sel);
+      GifSaveState.sel = null;
     }
   }
 }
@@ -45,7 +33,7 @@ export class GifPicker extends React.Component {
   constructor(props) {
     super(props);
 
-    this.closePopover = this.closePopover.bind(this);3
+    this.closePopover = this.closePopover.bind(this);
     this.render = this.render.bind(this);
   }
 
@@ -68,7 +56,7 @@ export class GifPicker extends React.Component {
   }
 }
 
-// Indivigual gif
+// Individual gif
 class Gif extends React.Component {
   static displayName = 'Gif';
 
@@ -84,11 +72,8 @@ class Gif extends React.Component {
     let gifElem = `<span><img src="${gifUrl}"></span>`;
     let elem = document.getElementsByClassName('contenteditable')[0];
 
-    let sel = window.getSelection();
-    let marker = document.getElementById('n1-gif-marker');
-    sel.setBaseAndExtent(marker, 0, marker, 0);
-    document.execCommand('insertHTML', true, gifElem);
     elem.focus();
+    document.execCommand('insertHTML', true, gifElem);
   }
 
   render() {


### PR DESCRIPTION
We're running into some issues with the marker node that gets inserted into the composer on blur - it can split text nodes and possibly cause issues for other plugins that want to work with the contenteditable. 

This'll replace the marker node logic with some code that just saves the selection on blur and restores it on focus, using utilities in `EditorAPI`. This retains the cursor position in the composer without mutating the DOM, letting the GIF still be inserted in the right place.